### PR TITLE
Fix error in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
         "build": "mkdir -p dist ; ./node_modules/.bin/browserify index.js -o dist/combokeys.js --standalone Combokeys",
         "test": "./node_modules/zuul/bin/zuul --phantom -- test/test.combokeys.js"
     },
-    "repositories": [{
+    "repository": {
         "type": "git",
         "url": "git://github.com/mightyiam/combokeys.git"
-    }],
+    },
     "keywords": [
         "keyboard",
         "shortcuts",


### PR DESCRIPTION
Fix for warning when installing combokeys package via npm install.

`npm WARN package.json combokeys@2.1.0 'repositories' (plural) Not supported. Please pick one as the 'repository' field`
