### PR TITLE
Add special keys 'plus' and 'minus', test for binding them

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ Combokeys.bind('up up down down left right left right b a enter', function() {
 });
 ```
 
+You can also bind the plus (and minus) keys conveniently:
+
+```
+Combokeys.bind(['mod+plus', 'mod+minus'], function(e) {
+    e.preventDefault();
+    console.log("Override browser zoom!");
+});
+```
+
 ## Why Combokeys?
 
 There are a number of other similar libraries out there so what makes this one different?

--- a/helpers/special-keys-map.js
+++ b/helpers/special-keys-map.js
@@ -31,6 +31,8 @@ module.exports = {
     46: "del",
     91: "meta",
     93: "meta",
+    187: "plus",
+    189: "minus",
     224: "meta"
 };
 

--- a/test/test.combokeys.js
+++ b/test/test.combokeys.js
@@ -244,6 +244,21 @@ describe("combokeys.bind", function() {
             expect(spy.callCount).to.equal(1, "callback should fire");
             expect(spy.args[0][1]).to.equal("left", "callback should match `left`");
         });
+
+        it("able to bind plus and minus", function() {
+            var spy1 = sinon.spy();
+            var spy2 = sinon.spy();
+
+            var combokeys = new Combokeys(document);
+            combokeys.bind("ctrl+minus", spy1);
+            combokeys.bind("ctrl+plus", spy2);
+
+            KeyEvent.simulate("-".charCodeAt(0), 189, ["ctrl"]);
+            expect(spy1.callCount).to.equal(1, "`ctrl+minus` should fire");
+
+            KeyEvent.simulate("+".charCodeAt(0), 187, ["ctrl"]);
+            expect(spy2.callCount).to.equal(1, "`ctrl+plus` should fire");
+        });
     });
 
     describe("combos with modifiers", function() {


### PR DESCRIPTION
From the times of mousetrap, binding the plus key hasn't worked, e.g. "ctrl++". The most straightforward way to make it possible to bind the plus key is to alias it. So, this PR adds special keys "plus" and "minus", which makes e.g. "ctrl+plus" work straight away, and a test case to verify it.


