### PR TITLE
Add Travis build configuration, readme "Build: passing" badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
 - 0.10
-script: npm run build && npm test
+script: npm test && npm run build
 notifications:
 email:
 - mike@arvela.net

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+- 0.10
+script: npm run build && npm test
+notifications:
+email:
+- mike@arvela.net

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
 - 0.10
+- 0.11
 script: npm test && npm run build
-notifications:
-email:
-- mike@arvela.net

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Combokeys
 
+[![Build Status](https://travis-ci.org/mieky/combokeys.svg?branch=master)](https://travis-ci.org/mieky/combokeys)
+
 Combokeys is a JavaScript library for handling keyboard shortcuts in the browser.
 
 It is licensed under the Apache 2.0 license.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Combokeys
 
-[![Build Status](https://travis-ci.org/mieky/combokeys.svg?branch=master)](https://travis-ci.org/mieky/combokeys)
+[![Build Status](https://travis-ci.org/mightyiam/combokeys.svg?branch=master)](https://travis-ci.org/mightyiam/combokeys)
 
 Combokeys is a JavaScript library for handling keyboard shortcuts in the browser.
 


### PR DESCRIPTION
Add a Travis-CI build for node 0.10 and 0.11, as well as a build badge in readme.

@mightyiam, to enable this, you only need to sign in at https://travis-ci.org/ with your GitHub account. There's a sample build enabled for my working branch: https://travis-ci.org/mieky/combokeys